### PR TITLE
Feat: scheduled at

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A [Model Context Protocol](https://github.com/thefocus/modelcontextprotocol) ser
 - Create toots with customizable visibility and content warnings
 - Upload and attach media files (images, videos, audio)
 - Add alt text/descriptions to media attachments
+- Schedule toots for a future time
 - Secure credential management using 1Password CLI
 
 ## Prerequisites
@@ -60,6 +61,7 @@ The server exposes a single tool `mastodon_create_toot` with the following param
 - `spoiler_text`: Warning text shown before the content (default: "")
 - `media_file`: Path to a media file to attach
 - `media_description`: Alt text/description for the attached media
+- `scheduled_at`: Optional ISO 8601 datetime to schedule the toot for a future time (e.g., "2024-07-04T10:00:00-07:00")
 
 ### Example Usage with MCP Inspector
 
@@ -78,7 +80,8 @@ npx @modelcontextprotocol/inspector node dist/mcp-server.js
   "content": "Hello from MCP!",
   "visibility": "public",
   "media_file": "/path/to/image.jpg",
-  "media_description": "A beautiful sunset"
+  "media_description": "A beautiful sunset",
+  "scheduled_at": "2025-01-01T12:00:00Z"
 }
 ```
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -3,6 +3,7 @@ import {
   MastodonStatus,
   MastodonError,
   MastodonMediaAttachment,
+  StatusOrScheduledStatus,
 } from "./mastodon_types.js";
 import { Readable } from "stream";
 
@@ -92,8 +93,8 @@ export class MastodonClient {
     }
   }
 
-  async createStatus(params: CreateStatusParams): Promise<MastodonStatus> {
-    return this.request<MastodonStatus>("/api/v1/statuses", "POST", {
+  async createStatus(params: CreateStatusParams): Promise<StatusOrScheduledStatus> {
+    const payload: CreateStatusParams = {
       status: params.status,
       visibility: params.visibility,
       sensitive: params.sensitive,
@@ -102,6 +103,10 @@ export class MastodonClient {
       media_ids: params.media_ids,
       poll: params.poll,
       in_reply_to_id: params.in_reply_to_id,
-    });
+    };
+    if (params.scheduled_at) {
+      payload.scheduled_at = params.scheduled_at;
+    }
+    return this.request<StatusOrScheduledStatus>("/api/v1/statuses", "POST", payload);
   }
 }

--- a/src/mastodon_tool.ts
+++ b/src/mastodon_tool.ts
@@ -28,8 +28,8 @@ const TootSchema = z.object({
     .optional(),
   scheduled_at: z
     .string()
-    .datetime({ message: "Invalid datetime string, expected ISO 8601 format (e.g., YYYY-MM-DDTHH:mm:ss.sssZ)" })
-    .describe("Optional ISO 8601 datetime string to schedule the toot for a future time. Example: 2024-01-01T10:00:00Z")
+    .datetime({ offset: true, message: "Invalid datetime string, expected ISO 8601 format (e.g., YYYY-MM-DDTHH:mm:ss.sssZ, YYYY-MM-DDTHH:mm:ss.sss+HH:MM)" })
+    .describe("Optional ISO 8601 datetime string to schedule the toot for a future time. Examples: 2024-01-01T10:00:00Z, 2024-01-01T10:00:00+01:00")
     .optional(),
 });
 

--- a/src/mastodon_tool.ts
+++ b/src/mastodon_tool.ts
@@ -26,6 +26,11 @@ const TootSchema = z.object({
     .string()
     .describe("Alt text / description for the attached media")
     .optional(),
+  scheduled_at: z
+    .string()
+    .datetime({ message: "Invalid datetime string, expected ISO 8601 format (e.g., YYYY-MM-DDTHH:mm:ss.sssZ)" })
+    .describe("Optional ISO 8601 datetime string to schedule the toot for a future time. Example: 2024-01-01T10:00:00Z")
+    .optional(),
 });
 
 type TootParams = z.infer<typeof TootSchema>;
@@ -57,24 +62,38 @@ export async function addMastodonTool(server: McpServer) {
         }
       }
 
-      const status = await client.createStatus({
+      const result = await client.createStatus({
         status: params.content,
         visibility: params.visibility,
         sensitive: params.sensitive,
         spoiler_text: params.spoiler_text,
         media_ids,
+        scheduled_at: params.scheduled_at,
       });
 
-      const mediaInfo =
-        status.media_attachments.length > 0
-          ? `\nMedia: ${status.media_attachments.map((m) => m.url).join(", ")}`
-          : "";
+      let successMessage: string;
+
+      // Check if 'url' property exists to differentiate MastodonStatus from ScheduledMastodonStatus
+      if ('url' in result) { // It's a MastodonStatus (posted immediately)
+        const mediaInfo =
+          result.media_attachments.length > 0
+            ? `\nMedia: ${result.media_attachments.map((m) => m.url).join(", ")}`
+            : "";
+        successMessage = `Successfully created toot! View it at: ${result.url}${mediaInfo}`;
+      } else { // It's a ScheduledMastodonStatus
+        const scheduledTime = new Date(result.scheduled_at).toLocaleString();
+        let mediaInfo = "";
+        if (result.media_attachments && result.media_attachments.length > 0) {
+            mediaInfo = `\nMedia will be attached: ${result.media_attachments.length} item(s).`;
+        }
+        successMessage = `Successfully scheduled toot! ID: ${result.id}. It will be posted at: ${scheduledTime}.${mediaInfo}`;
+      }
 
       return {
         content: [
           {
             type: "text",
-            text: `Successfully created toot! View it at: ${status.url}${mediaInfo}`,
+            text: successMessage,
           },
         ],
       };

--- a/src/mastodon_types.ts
+++ b/src/mastodon_types.ts
@@ -113,8 +113,36 @@ export interface CreateStatusParams {
     hide_totals?: boolean;
   };
   in_reply_to_id?: string;
+  scheduled_at?: string; // ISO 8601 datetime string
 }
 
 export interface MastodonError {
   error: string;
 }
+
+// Represents the parameters of a scheduled status, as returned by the API
+export interface ScheduledMastodonStatusParams {
+  text: string;
+  poll?: {
+    options: string[];
+    expires_in: number; // Duration in seconds
+    multiple?: boolean;
+    hide_totals?: boolean;
+  };
+  media_ids?: string[];
+  sensitive?: boolean;
+  spoiler_text?: string;
+  visibility?: "public" | "unlisted" | "private" | "direct";
+  in_reply_to_id?: string | null;
+  language?: string;
+  scheduled_at?: string | null; // This is the 'params.scheduled_at' from OpenAPI, likely null if top-level scheduled_at is used
+}
+
+export interface ScheduledMastodonStatus {
+  id: string;
+  scheduled_at: string; // ISO 8601 datetime string for when it will be posted
+  params: ScheduledMastodonStatusParams;
+  media_attachments: MastodonMediaAttachment[];
+}
+
+export type StatusOrScheduledStatus = MastodonStatus | ScheduledMastodonStatus;

--- a/src/mastodon_types.ts
+++ b/src/mastodon_types.ts
@@ -135,7 +135,7 @@ export interface ScheduledMastodonStatusParams {
   visibility?: "public" | "unlisted" | "private" | "direct";
   in_reply_to_id?: string | null;
   language?: string;
-  scheduled_at?: string | null; // This is the 'params.scheduled_at' from OpenAPI, likely null if top-level scheduled_at is used
+  scheduled_at?: string | null;
 }
 
 export interface ScheduledMastodonStatus {


### PR DESCRIPTION
Add feature to schedule toots using the `scheduled_at` parameter. Reflecting the Mastodon API `scheduled_at` must be an ISO 8601 datetime string. A timezone indicator must be included (`Z` for `UTC`, or an hour offset like `+01:00`).