### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A [Model Context Protocol](https://github.com/thefocus/modelcontextprotocol) server that provides tools for interacting with Mastodon. Currently supports creating toots with optional media attachments.
 
+<a href="https://glama.ai/mcp/servers/@The-Focus-AI/mastodon-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@The-Focus-AI/mastodon-mcp/badge" alt="Mastodon MCP server" />
+</a>
+
 ## Features
 
 - Create toots with customizable visibility and content warnings


### PR DESCRIPTION
This PR adds a badge for the [Mastodon MCP](https://glama.ai/mcp/servers/@The-Focus-AI/mastodon-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@The-Focus-AI/mastodon-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@The-Focus-AI/mastodon-mcp/badge" alt="Mastodon MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.